### PR TITLE
Fix #5 - Remove safe_mode check and set_time_limit()

### DIFF
--- a/inc/class-checksum-verifier.php
+++ b/inc/class-checksum-verifier.php
@@ -125,11 +125,6 @@ class Checksum_Verifier {
 	 * @return  array            File paths
 	 */
 	private static function _match_checksums( $checksums ) {
-		// Reset time limit.
-		if ( ! ini_get( 'safe_mode' ) ) {
-			set_time_limit( 0 );
-		}
-
 		// Ignore files filter.
 		$ignore_files = (array) apply_filters(
 			'checksum_verifier_ignore_files',


### PR DESCRIPTION
As @swissspidy  correctly stated in #5 a year ago, `safe_mode` is removed as of PHP 5.4, so the check should always return `false` nowadays. Not really a bug, but still superfluous.

Simply removing the check though might break PHP 5.3 compatibility when safe_mode is active (verifying WP integrity with insecure PHP ... why bothe). So I also removed the `set_time_limit(0)`.

Local benchmarks completed the check in ~0.1 seconds, even if it's 1-2s on slower systems this should be within any reasonable limit (30s by default). Might consider adding a note somewhere, but I wouldn't expect complications here.